### PR TITLE
Merge hot fix to main

### DIFF
--- a/client/src/components/AddExerciseModal/AddExerciseModal.scss
+++ b/client/src/components/AddExerciseModal/AddExerciseModal.scss
@@ -8,8 +8,7 @@
   transition: 0.3s;
 
   &--closing {
-    opacity: 0;
-    transform: scale(3) translate(-25%, -25%);
+    transform: translate(-50%, -150vh);
   }
 
   &__overlay {

--- a/client/src/components/AddLiftModal/AddLiftModal.scss
+++ b/client/src/components/AddLiftModal/AddLiftModal.scss
@@ -8,8 +8,7 @@
   transition: 0.3s;
 
   &--closing {
-    opacity: 0;
-    transform: scale(3) translate(-25%, -25%);
+    transform: translate(-50%, -150vh);
   }
   
   &__container {

--- a/client/src/components/DeleteModal/DeleteModal.scss
+++ b/client/src/components/DeleteModal/DeleteModal.scss
@@ -8,8 +8,7 @@
   transition: 0.3s;
 
   &--closing {
-    opacity: 0;
-    transform: scale(3) translate(-25%, -25%);
+    transform: translate(-50%, -150vh);
   }
 
   &__overlay {

--- a/client/src/components/EditExerciseModal/EditExerciseModal.scss
+++ b/client/src/components/EditExerciseModal/EditExerciseModal.scss
@@ -8,8 +8,7 @@
   transition: 0.3s;
 
   &--closing {
-    opacity: 0;
-    transform: scale(3) translate(-25%, -25%);
+    transform: translate(-50%, -150vh);
   }
 
   &__overlay {

--- a/client/src/components/EditLiftModal/EditLiftModal.scss
+++ b/client/src/components/EditLiftModal/EditLiftModal.scss
@@ -8,8 +8,7 @@
   transition: 0.3s;
 
   &--closing {
-    opacity: 0;
-    transform: scale(3) translate(-25%, -25%);
+    transform: translate(-50%, -150vh);
   }
 
   &__container {

--- a/client/src/components/NewWorkoutModal/NewWorkoutModal.scss
+++ b/client/src/components/NewWorkoutModal/NewWorkoutModal.scss
@@ -5,12 +5,6 @@
 
 .new-workout {
   @include modal;
-  transition: 0.3s;
-
-  &--closing {
-    opacity: 0;
-    transform: scale(3) translate(-25%, -25%);
-  }
 
   &__container {
     @include modal-top-level-container;

--- a/client/src/components/RenameWorkoutModal/RenameWorkoutModal.scss
+++ b/client/src/components/RenameWorkoutModal/RenameWorkoutModal.scss
@@ -8,8 +8,7 @@
   transition: 0.3s;
 
   &--closing {
-    opacity: 0;
-    transform: scale(3) translate(-25%, -25%);
+    transform: translate(-50%, -150vh);
   }
 
   &__container {

--- a/client/src/pages/WorkoutPage/WorkoutPage.js
+++ b/client/src/pages/WorkoutPage/WorkoutPage.js
@@ -184,7 +184,7 @@ const WorkoutPage = ({token}) => {
 
   const editLiftHandler = (e, id) => {
     e.preventDefault()
-    const exercise = findExerciseByName
+    const exercise = findExerciseByName(e.target.exercise.value)
     const newLift = validateLiftForm(e, exercise, id)
     if(!newLift.error) {
       delete newLift.error


### PR DESCRIPTION
This hot fix addresses a front end issue where editLiftHandler was not properly invoking findExerciseByName resulting in unwanted behaviour. It also addresses the somewhat unpredictable behaviour of the "successful close" modal animations by removing the opacity change from the animation and only animating translate as opposed to animating translate and scale.